### PR TITLE
Manual calibration improved : now as precise as last auto calibration

### DIFF
--- a/niryo_one_driver/CMakeLists.txt
+++ b/niryo_one_driver/CMakeLists.txt
@@ -39,6 +39,7 @@ include_directories(include ${catkin_INCLUDE_DIRS})
 
 add_executable(niryo_one_driver
     src/utils/change_hardware_version.cpp
+    src/utils/motor_offset_file_handler.cpp
     src/hw_driver/niryo_one_can_driver.cpp
     src/hw_driver/dxl_driver.cpp
     src/hw_driver/xl320_driver.cpp

--- a/niryo_one_driver/include/niryo_one_driver/can_communication.h
+++ b/niryo_one_driver/include/niryo_one_driver/can_communication.h
@@ -101,6 +101,7 @@ class CanCommunication {
         
         int scanAndCheck();
 
+        bool canProcessManualCalibration(std::string &result_message);
         void validateMotorsCalibrationFromUserInput(int mode);
         void setCalibrationFlag(bool flag);
 

--- a/niryo_one_driver/include/niryo_one_driver/can_communication.h
+++ b/niryo_one_driver/include/niryo_one_driver/can_communication.h
@@ -28,6 +28,7 @@
 
 #include "niryo_one_driver/stepper_motor_state.h"
 #include "niryo_one_driver/niryo_one_can_driver.h"
+#include "niryo_one_driver/motor_offset_file_handler.h"
 
 #define TIME_TO_WAIT_IF_BUSY 0.0005
 
@@ -95,7 +96,8 @@ class CanCommunication {
         int autoCalibrationStep2();
         int sendCalibrationCommandForOneMotor(StepperMotorState* motor, int delay_between_steps,
                 int calibration_direction, int calibration_timeout);
-        int getCalibrationResults(std::vector<StepperMotorState*> steppers, int calibration_timeout);
+        int getCalibrationResults(std::vector<StepperMotorState*> steppers, int calibration_timeout,
+                std::vector<int> &sensor_offset_ids, std::vector<int> &sensor_offset_steps);
         
         int scanAndCheck();
 

--- a/niryo_one_driver/include/niryo_one_driver/communication_base.h
+++ b/niryo_one_driver/include/niryo_one_driver/communication_base.h
@@ -53,7 +53,7 @@ class CommunicationBase {
         virtual void activateLearningMode(bool activate) = 0;
         virtual bool setLeds(std::vector<int> &leds, std::string &message) = 0;
 
-        virtual int allowMotorsCalibrationToStart(int mode) = 0;
+        virtual int allowMotorsCalibrationToStart(int mode, std::string &result_message) = 0;
         virtual void requestNewCalibration() = 0;
         virtual bool isCalibrationInProgress() = 0;
 

--- a/niryo_one_driver/include/niryo_one_driver/fake_communication.h
+++ b/niryo_one_driver/include/niryo_one_driver/fake_communication.h
@@ -57,7 +57,7 @@ class FakeCommunication : public CommunicationBase {
         void activateLearningMode(bool activate);
         bool setLeds(std::vector<int> &leds, std::string &message);
         
-        int allowMotorsCalibrationToStart(int mode);
+        int allowMotorsCalibrationToStart(int mode, std::string &result_message);
         void requestNewCalibration();
         bool isCalibrationInProgress();
         

--- a/niryo_one_driver/include/niryo_one_driver/motor_offset_file_handler.h
+++ b/niryo_one_driver/include/niryo_one_driver/motor_offset_file_handler.h
@@ -1,0 +1,35 @@
+/*
+    motor_offset_file_handler.h
+    Copyright (C) 2018 Niryo
+    All rights reserved.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef MOTOR_OFFSET_FILE_HANDLER_H
+#define MOTOR_OFFSET_FILE_HANDLER_H
+
+#include <ros/ros.h>
+#include <vector>
+#include <string>
+#include <unistd.h>
+
+// TODO : remplacer offset par middle
+// avant d'envoyer, compute le middle en fct de offset et valeur lue
+
+bool get_motors_calibration_offsets(std::vector<int> &motor_id_list,  std::vector<int> &steps_list);
+
+bool set_motors_calibration_offsets(std::vector<int> &motor_id_list,  std::vector<int> &steps_list);
+
+#endif

--- a/niryo_one_driver/include/niryo_one_driver/motor_offset_file_handler.h
+++ b/niryo_one_driver/include/niryo_one_driver/motor_offset_file_handler.h
@@ -25,9 +25,6 @@
 #include <string>
 #include <unistd.h>
 
-// TODO : remplacer offset par middle
-// avant d'envoyer, compute le middle en fct de offset et valeur lue
-
 bool get_motors_calibration_offsets(std::vector<int> &motor_id_list,  std::vector<int> &steps_list);
 
 bool set_motors_calibration_offsets(std::vector<int> &motor_id_list,  std::vector<int> &steps_list);

--- a/niryo_one_driver/include/niryo_one_driver/niryo_one_communication.h
+++ b/niryo_one_driver/include/niryo_one_driver/niryo_one_communication.h
@@ -61,7 +61,7 @@ class NiryoOneCommunication : public CommunicationBase {
         void activateLearningMode(bool activate);
         bool setLeds(std::vector<int> &leds, std::string &message);
         
-        int allowMotorsCalibrationToStart(int mode);
+        int allowMotorsCalibrationToStart(int mode, std::string &result_message);
         void requestNewCalibration();
         bool isCalibrationInProgress();
         

--- a/niryo_one_driver/src/hw_comm/fake_communication.cpp
+++ b/niryo_one_driver/src/hw_comm/fake_communication.cpp
@@ -86,7 +86,7 @@ bool FakeCommunication::isConnectionOk()
     return true;
 }
 
-int FakeCommunication::allowMotorsCalibrationToStart(int mode)
+int FakeCommunication::allowMotorsCalibrationToStart(int mode, std::string &result_message)
 {
     ROS_INFO("Motor calibration with mode : %d", mode);
     return 1;

--- a/niryo_one_driver/src/hw_comm/niryo_one_communication.cpp
+++ b/niryo_one_driver/src/hw_comm/niryo_one_communication.cpp
@@ -299,18 +299,22 @@ void NiryoOneCommunication::synchronizeMotors(bool begin_traj)
     }
 }
 
-int NiryoOneCommunication::allowMotorsCalibrationToStart(int mode)
+int NiryoOneCommunication::allowMotorsCalibrationToStart(int mode, std::string &result_message)
 {
-    int result = CAN_STEPPERS_CALIBRATION_OK; // todo
-
     if (can_enabled) {
+        if (mode == CAN_STEPPERS_CALIBRATION_MODE_MANUAL) {
+            if (!canComm->canProcessManualCalibration(result_message)) {
+                return 400;
+            }
+        }
         canComm->validateMotorsCalibrationFromUserInput(mode);
     }
     if (dxl_enabled) {
         // todo check dxl in bounds
     }
     
-    return result;
+    result_message = "Calibration is starting";
+    return 200;
 }
 
 void NiryoOneCommunication::requestNewCalibration()

--- a/niryo_one_driver/src/ros_interface.cpp
+++ b/niryo_one_driver/src/ros_interface.cpp
@@ -47,10 +47,11 @@ RosInterface::RosInterface(CommunicationBase* niryo_one_comm, RpiDiagnostics* rp
 bool RosInterface::callbackCalibrateMotors(niryo_one_msgs::SetInt::Request &req, niryo_one_msgs::SetInt::Response &res) 
 {
     int calibration_mode = req.value; 
-    int result = comm->allowMotorsCalibrationToStart(calibration_mode);
+    std::string result_message = "";
+    int result = comm->allowMotorsCalibrationToStart(calibration_mode, result_message);
 
-    res.status = 200;
-    res.message = "Calibration is starting";
+    res.status = result;
+    res.message = result_message;
 
     // special case here 
     // we set flag learning_mode_on, but we don't activate from here

--- a/niryo_one_driver/src/utils/motor_offset_file_handler.cpp
+++ b/niryo_one_driver/src/utils/motor_offset_file_handler.cpp
@@ -1,0 +1,100 @@
+/*
+    motor_offset_file_handler.h
+    Copyright (C) 2018 Niryo
+    All rights reserved.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "niryo_one_driver/motor_offset_file_handler.h"
+
+#include "boost/filesystem.hpp"
+#include <iostream>
+#include <fstream>
+#include <exception>
+
+bool get_motors_calibration_offsets(std::vector<int> &motor_id_list,  std::vector<int> &steps_list)
+{
+    std::string file_name = "/home/niryo/niryo_one_saved_values/stepper_motor_calibration_offsets.txt"; // Todo rosparam
+    std::vector<std::string> lines;
+    std::string current_line;
+    
+    std::ifstream offset_file(file_name.c_str());
+    if (offset_file.is_open()) {
+        while (std::getline(offset_file, current_line)) {
+            try {
+                size_t index = current_line.find(":");
+                motor_id_list.push_back(stoi(current_line.substr(0, index)));
+                steps_list.push_back(stoi(current_line.erase(0, index + 1)));
+            }
+            catch (std::exception& e) {
+            
+            }
+        }
+        offset_file.close();
+    }
+    else {
+        ROS_WARN("Unable to open file : %s", file_name.c_str());
+        return false;
+    }
+   
+    return true;
+}
+
+bool set_motors_calibration_offsets(std::vector<int> &motor_id_list, std::vector<int> &steps_list)
+{
+    if (motor_id_list.size() != steps_list.size()) {
+        return false;
+    }
+
+    std::string file_name = "/home/niryo/niryo_one_saved_values/stepper_motor_calibration_offsets.txt"; // Todo rosparam
+    size_t found = file_name.find_last_of("/");
+    std::string folder_name = file_name.substr(0, found);
+
+    boost::filesystem::path filepath(file_name);
+    boost::filesystem::path directory(folder_name);
+
+    // Create dir if not exist
+    boost::system::error_code returned_error;
+    boost::filesystem::create_directories(directory, returned_error);
+    if (returned_error) {
+        ROS_WARN("Could not create directory : %s", folder_name.c_str()); 
+        return false;
+    }
+
+    // Create text to write
+    std::string text_to_write = "";
+    for (int i = 0; i < motor_id_list.size(); i++) {
+        text_to_write += std::to_string(motor_id_list.at(i));
+        text_to_write += ":"; 
+        text_to_write += std::to_string(steps_list.at(i));
+        if (i < motor_id_list.size() - 1) {
+            text_to_write += "\n";
+        }
+    }
+
+    // Write to file
+    std::ofstream offset_file(file_name.c_str()); 
+    if (offset_file.is_open()) {
+        ROS_INFO("Writing calibration offsets to file : \n%s", text_to_write.c_str());
+        offset_file << text_to_write.c_str();
+        offset_file.close();
+    }
+    else {
+        ROS_WARN("Unable to open file : %s", file_name.c_str());
+        return false;
+    }
+
+    return true;
+}


### PR DESCRIPTION
- User needs first to do an auto calibration.
- The absolute (sensor) steps are saved on the RPi3
- User can know use manual calibration, by placing the robot at "almost" home position
- Absolute (sensor) steps will be read and will enable to calculate the offset so the manual calibration has the same precision as the last auto calibration

--> Saves time (~30 s) and reduces the wear of mechanical parts
