### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ Create a catkin workspace and clone Niryo One ROS stack :
 ```
 mkdir -p ~/catkin_ws/src
 cd ~/catkin_ws/src
-git clone https://github.com/NiryoRobotics/niryo_one_ros.git .
+git init
+git remote add origin https://github.com/NiryoRobotics/niryo_one_ros.git
+git pull origin master
 ```
 Build the packages :
 ```


### PR DESCRIPTION
To help those having the problem :
"sudo: pip: command not found"

And to help those having difficulties to clone a github repo in an non empty repository :
"fatal: destination path '.' already exists and is not an empty directory."