### PR TITLE
make niryo one compile on aarch64

### DIFF
--- a/dynamixel_sdk/CMakeLists.txt
+++ b/dynamixel_sdk/CMakeLists.txt
@@ -55,7 +55,7 @@ add_dependencies(dynamixel_sdk ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPO
 EXECUTE_PROCESS( COMMAND uname -m COMMAND tr -d '\n' OUTPUT_VARIABLE ARCHITECTURE )
 message( STATUS "Architecture: ${ARCHITECTURE}" )
 
-if (${ARCHITECTURE} MATCHES "arm")
+if (${ARCHITECTURE} MATCHES "arm|aarch64")
     message(STATUS "wiringPi library is required - arm processor")
     target_link_libraries(dynamixel_sdk
         ${catkin_LIBRARIES} 

--- a/dynamixel_sdk/CMakeLists.txt
+++ b/dynamixel_sdk/CMakeLists.txt
@@ -55,7 +55,7 @@ add_dependencies(dynamixel_sdk ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPO
 EXECUTE_PROCESS( COMMAND uname -m COMMAND tr -d '\n' OUTPUT_VARIABLE ARCHITECTURE )
 message( STATUS "Architecture: ${ARCHITECTURE}" )
 
-if (${ARCHITECTURE} MATCHES "arm|aarch64")
+if (${ARCHITECTURE} MATCHES "(arm|aarch64)")
     message(STATUS "wiringPi library is required - arm processor")
     target_link_libraries(dynamixel_sdk
         ${catkin_LIBRARIES} 

--- a/dynamixel_sdk/src/port_handler_linux.cpp
+++ b/dynamixel_sdk/src/port_handler_linux.cpp
@@ -67,7 +67,7 @@ PortHandlerLinux::PortHandlerLinux(const char *port_name)
 }
 
 #include <fcntl.h>
-#ifdef __arm__
+#if defined(__arm__) || defined(__aarch64__)
 #include <wiringPi.h>
 #endif
 #include <time.h>
@@ -76,7 +76,7 @@ PortHandlerLinux::PortHandlerLinux(const char *port_name)
 
 bool PortHandlerLinux::setupGpio()
 {
-#ifdef __arm__
+#if defined(__arm__) || defined(__aarch64__)
   int result = wiringPiSetupGpio();
   if (!result) {
       //printf("Gpio started\n");
@@ -98,14 +98,14 @@ bool PortHandlerLinux::setupGpio()
 
 void PortHandlerLinux::gpioHigh()
 {
-#ifdef __arm__
+#if defined(__arm__) || defined(__aarch64__)
   digitalWrite(GPIO_HALF_DUPLEX_DIRECTION, HIGH);
 #endif
 }
 
 void PortHandlerLinux::gpioLow()
 {
-#ifdef __arm__
+#if defined(__arm__) || defined(__aarch64__)
   digitalWrite(GPIO_HALF_DUPLEX_DIRECTION, LOW);
 #endif
 }

--- a/mcp_can_rpi/CMakeLists.txt
+++ b/mcp_can_rpi/CMakeLists.txt
@@ -31,7 +31,7 @@ add_dependencies(mcp_can_rpi ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORT
 EXECUTE_PROCESS( COMMAND uname -m COMMAND tr -d '\n' OUTPUT_VARIABLE ARCHITECTURE )
 message( STATUS "Architecture: ${ARCHITECTURE}" )
 
-if (${ARCHITECTURE} MATCHES "arm|aarch64")
+if (${ARCHITECTURE} MATCHES "(arm|aarch64)")
     message(STATUS "wiringPi library is required for mcp_can_rpi (ARM processor)")
     target_link_libraries(mcp_can_rpi
         ${catkin_LIBRARIES} 

--- a/mcp_can_rpi/CMakeLists.txt
+++ b/mcp_can_rpi/CMakeLists.txt
@@ -31,7 +31,7 @@ add_dependencies(mcp_can_rpi ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORT
 EXECUTE_PROCESS( COMMAND uname -m COMMAND tr -d '\n' OUTPUT_VARIABLE ARCHITECTURE )
 message( STATUS "Architecture: ${ARCHITECTURE}" )
 
-if (${ARCHITECTURE} MATCHES "arm")
+if (${ARCHITECTURE} MATCHES "arm|aarch64")
     message(STATUS "wiringPi library is required for mcp_can_rpi (ARM processor)")
     target_link_libraries(mcp_can_rpi
         ${catkin_LIBRARIES} 

--- a/mcp_can_rpi/include/mcp_can_rpi/mcp_can_rpi.h
+++ b/mcp_can_rpi/include/mcp_can_rpi/mcp_can_rpi.h
@@ -43,7 +43,7 @@
 #ifndef MCP_CAN_RPI_H
 #define MCP_CAN_RPI_H
 
-#ifdef __arm__
+#if defined(__arm__) || defined(__aarch64__)
 #include <wiringPi.h>
 #include <wiringPiSPI.h>
 #endif

--- a/mcp_can_rpi/src/mcp_can_rpi.cpp
+++ b/mcp_can_rpi/src/mcp_can_rpi.cpp
@@ -47,7 +47,7 @@
 *********************************************************************************************************/
 void MCP_CAN::spiTransfer(uint8_t byte_number, unsigned char *buf)
 {
-#ifdef __arm__
+#if defined(__arm__) || defined(__aarch64__)
     wiringPiSPIDataRW(spi_channel, buf, byte_number);
     nanosleep(&delay_spi_can, (struct timespec *)NULL); 
 #endif
@@ -59,7 +59,7 @@ void MCP_CAN::spiTransfer(uint8_t byte_number, unsigned char *buf)
 *********************************************************************************************************/
 bool MCP_CAN::setupInterruptGpio()
 {
-#ifdef __arm__
+#if defined(__arm__) || defined(__aarch64__)
     int result = wiringPiSetupGpio();
     if (!result) {
         printf("Gpio started\n");
@@ -84,7 +84,7 @@ bool MCP_CAN::setupInterruptGpio()
 *********************************************************************************************************/
 bool MCP_CAN::setupSpi()
 {
-#ifdef __arm__
+#if defined(__arm__) || defined(__aarch64__)
 	int result_spi = wiringPiSPISetup(spi_channel, spi_baudrate);
     printf("Started SPI : %d\n", result_spi);
     if (result_spi < 0) {
@@ -104,7 +104,7 @@ bool MCP_CAN::setupSpi()
 *********************************************************************************************************/
 bool MCP_CAN::canReadData()
 {
-#ifdef __arm__
+#if defined(__arm__) || defined(__aarch64__)
     return !digitalRead(gpio_can_interrupt);
 #else
     return false;

--- a/niryo_one_debug/CMakeLists.txt
+++ b/niryo_one_debug/CMakeLists.txt
@@ -38,7 +38,7 @@ add_executable(dxl_debug_tools
 EXECUTE_PROCESS( COMMAND uname -m COMMAND tr -d '\n' OUTPUT_VARIABLE ARCHITECTURE )
 message( STATUS "Architecture: ${ARCHITECTURE}" )
 
-if (${ARCHITECTURE} MATCHES "arm|aarch64")
+if (${ARCHITECTURE} MATCHES "(arm|aarch64)")
     message(STATUS "wiringPi library is required - arm processor")
     target_link_libraries(dxl_debug_tools
         ${catkin_LIBRARIES} 

--- a/niryo_one_debug/CMakeLists.txt
+++ b/niryo_one_debug/CMakeLists.txt
@@ -38,7 +38,7 @@ add_executable(dxl_debug_tools
 EXECUTE_PROCESS( COMMAND uname -m COMMAND tr -d '\n' OUTPUT_VARIABLE ARCHITECTURE )
 message( STATUS "Architecture: ${ARCHITECTURE}" )
 
-if (${ARCHITECTURE} MATCHES "arm")
+if (${ARCHITECTURE} MATCHES "arm|aarch64")
     message(STATUS "wiringPi library is required - arm processor")
     target_link_libraries(dxl_debug_tools
         ${catkin_LIBRARIES} 

--- a/niryo_one_driver/CMakeLists.txt
+++ b/niryo_one_driver/CMakeLists.txt
@@ -63,7 +63,7 @@ add_executable(${PROJECT_NAME}
 EXECUTE_PROCESS( COMMAND uname -m COMMAND tr -d '\n' OUTPUT_VARIABLE ARCHITECTURE )
 message( STATUS "Architecture: ${ARCHITECTURE}" )
 
-if (${ARCHITECTURE} MATCHES "arm|aarch64")
+if (${ARCHITECTURE} MATCHES "(arm|aarch64)")
     message(STATUS "wiringPi library is required - arm processor")
     target_link_libraries(niryo_one_driver
         ${catkin_LIBRARIES} 

--- a/niryo_one_driver/CMakeLists.txt
+++ b/niryo_one_driver/CMakeLists.txt
@@ -63,7 +63,7 @@ add_executable(${PROJECT_NAME}
 EXECUTE_PROCESS( COMMAND uname -m COMMAND tr -d '\n' OUTPUT_VARIABLE ARCHITECTURE )
 message( STATUS "Architecture: ${ARCHITECTURE}" )
 
-if (${ARCHITECTURE} MATCHES "arm")
+if (${ARCHITECTURE} MATCHES "arm|aarch64")
     message(STATUS "wiringPi library is required - arm processor")
     target_link_libraries(niryo_one_driver
         ${catkin_LIBRARIES} 

--- a/niryo_one_driver/include/niryo_one_driver/rpi_diagnostics.h
+++ b/niryo_one_driver/include/niryo_one_driver/rpi_diagnostics.h
@@ -20,7 +20,7 @@
 #ifndef RPI_DIAGNOSTICS_H
 #define RPI_DIAGNOSTICS_H
 
-#ifdef __arm__
+#if defined(__arm__) || defined(__aarch64__)
 #include <fstream> 
 #endif
 

--- a/niryo_one_driver/src/rpi_diagnostics.cpp
+++ b/niryo_one_driver/src/rpi_diagnostics.cpp
@@ -33,7 +33,7 @@ int RpiDiagnostics::getRpiCpuTemperature()
 
 void RpiDiagnostics::readCpuTemperature()
 {
-#ifdef __arm__
+#if defined(__arm__) || defined(__aarch64__)
     std::fstream cpu_temp_file("/sys/class/thermal/thermal_zone0/temp", std::ios_base::in);
     
     int read_temp;

--- a/niryo_one_driver/src/utils/change_hardware_version.cpp
+++ b/niryo_one_driver/src/utils/change_hardware_version.cpp
@@ -21,7 +21,7 @@
 
 int change_hardware_version_and_reboot(int old_version, int new_version)
 {
-#ifdef __arm__
+#if defined(__arm__) || defined(__aarch64__)
     
     std::ostringstream text;
     


### PR DESCRIPTION
I've got a Niryo One working with a Ubuntu 18.04 64 bit base image and ROS melodic. These were the changes I had to make.